### PR TITLE
Prevent duplicated status bar item creation

### DIFF
--- a/lib/indent-detective.js
+++ b/lib/indent-detective.js
@@ -28,6 +28,8 @@ export function activate () {
   subs.add(atom.workspace.onDidStopChangingActivePaneItem((item) => {
     if (item instanceof TextEditor) {
       run(item)
+    } else {
+      status.clear()
     }
   }))
   subs.add(atom.commands.add('atom-text-editor', {
@@ -52,9 +54,9 @@ export function consumeStatusBar (bar) {
 }
 
 function run (editor) {
-  if (manual.has(editor) || editor.isDestroyed()) return
+  if (editor.isDestroyed()) return
+  if (!manual.has(editor)) setSettings(editor, getIndent(editor))
 
-  setSettings(editor, getIndent(editor))
   status.updateText()
 }
 
@@ -159,7 +161,7 @@ function select () {
     } else {
       setSettings(editor, length)
       manual.add(editor)
-      status.update()
+      status.updateText()
     }
   })
 }

--- a/lib/indent-detective.js
+++ b/lib/indent-detective.js
@@ -13,32 +13,34 @@ export function activate () {
   subs = new CompositeDisposable()
   status.activate()
 
-  subs.add(atom.workspace.observeTextEditors((ed) => {
-    run(ed)
-    const sub = ed.onDidStopChanging(() => {
+  subs.add(
+    atom.workspace.observeTextEditors((ed) => {
       run(ed)
+      const sub = ed.onDidStopChanging(() => {
+        run(ed)
+      })
+      subs.add(ed.onDidDestroy(() => {
+        sub.dispose()
+        manual.delete(ed)
+      }))
+    }),
+    atom.workspace.onDidStopChangingActivePaneItem((item) => {
+      if (item instanceof TextEditor) {
+        run(item)
+      } else {
+        status.clear()
+      }
+    }),
+    atom.commands.add('atom-text-editor', {
+      'indent-detective:choose-indent': () => select()
+    }),
+    atom.config.observe('indent-detective.possibleIndentations', (opts) => {
+      possibleIndentations = opts.map(el => parseInt(el))
+    }),
+    atom.config.observe('indent-detective.enableDebugMessages', (val) => {
+      enableDebug = val
     })
-    subs.add(ed.onDidDestroy(() => {
-      sub.dispose()
-      manual.delete(ed)
-    }))
-  }))
-  subs.add(atom.workspace.onDidStopChangingActivePaneItem((item) => {
-    if (item instanceof TextEditor) {
-      run(item)
-    } else {
-      status.clear()
-    }
-  }))
-  subs.add(atom.commands.add('atom-text-editor', {
-    'indent-detective:choose-indent': () => select()
-  }))
-  subs.add(atom.config.observe('indent-detective.possibleIndentations', (opts) => {
-    possibleIndentations = opts.map(el => parseInt(el))
-  }))
-  subs.add(atom.config.observe('indent-detective.enableDebugMessages', (val) => {
-    enableDebug = val
-  }))
+  )
 }
 
 export function deactivate () {

--- a/lib/indent-detective.js
+++ b/lib/indent-detective.js
@@ -1,6 +1,6 @@
 'use babel'
 
-import { CompositeDisposable, TextEditor } from 'atom'
+import { CompositeDisposable } from 'atom'
 import status from './status'
 import selector from './selector'
 
@@ -24,12 +24,8 @@ export function activate () {
         manual.delete(ed)
       }))
     }),
-    atom.workspace.onDidStopChangingActivePaneItem((item) => {
-      if (item instanceof TextEditor) {
-        run(item)
-      } else {
-        status.clear()
-      }
+    atom.workspace.onDidStopChangingActivePaneItem((_item) => {
+      status.update()
     }),
     atom.commands.add('atom-text-editor', {
       'indent-detective:choose-indent': () => select()
@@ -57,7 +53,7 @@ function run (editor) {
   if (editor.isDestroyed()) return
   if (!manual.has(editor)) setSettings(editor, getIndent(editor))
 
-  status.updateText()
+  status.updateText(editor)
 }
 
 function setSettings (editor, indent) {
@@ -161,7 +157,7 @@ function select () {
     } else {
       setSettings(editor, length)
       manual.add(editor)
-      status.updateText()
+      status.updateText(editor)
     }
   })
 }

--- a/lib/indent-detective.js
+++ b/lib/indent-detective.js
@@ -6,18 +6,16 @@ import selector from './selector'
 
 let possibleIndentations = []
 let enableDebug = false
-let manual = new Set()
+const manual = new Set()
 let subs
 
 export function activate () {
   subs = new CompositeDisposable()
-
   status.activate()
 
   subs.add(atom.workspace.observeTextEditors((ed) => {
     run(ed)
-
-    let sub = ed.onDidStopChanging(() => {
+    const sub = ed.onDidStopChanging(() => {
       run(ed)
     })
     subs.add(ed.onDidDestroy(() => {
@@ -90,18 +88,18 @@ function bestOf (counts) {
 
 function getIndent (editor) {
   let row = -1
-  let counts = {}
+  const counts = {}
   let previousIndent = 0
   let previousDiff = 0
   let numberOfCounts = 0
-  for (let line of editor.getBuffer().getLines()) {
+  for (const line of editor.getBuffer().getLines()) {
     if (numberOfCounts > 150) break
     row += 1
     if (!isValidLine(row, line, editor)) continue
-    let indent = lineIndent(line)
+    const indent = lineIndent(line)
 
     if (indent == 'tab') return 'tab'
-    let diff = Math.abs(indent - previousIndent)
+    const diff = Math.abs(indent - previousIndent)
 
     if (diff == 0) {
       if (previousDiff != 0 && indent != 0) {
@@ -128,7 +126,7 @@ function isValidLine (row, line, editor) {
   if (line.match(/^\s*$/)) return false
 
   // line is part of a comment or string
-  for (let scope of editor.scopeDescriptorForBufferPosition([row, 0]).scopes) {
+  for (const scope of editor.scopeDescriptorForBufferPosition([row, 0]).scopes) {
     if (scope.indexOf('comment') > -1 ||
         scope.indexOf('docstring') > -1 ||
         scope.indexOf('string') > -1) {
@@ -148,13 +146,13 @@ function lineIndent (line) {
 }
 
 function select () {
-  let items = [{text: 'Automatic'}]
-  for (let n of possibleIndentations) {
+  const items = [{text: 'Automatic'}]
+  for (const n of possibleIndentations) {
     items.push({text: `${n} Spaces`, length: n})
   }
   items.push({text: 'Tabs', length: 'tab'})
-  let sel = selector.show(items, ({text, length}={}) =>{
-    let editor = atom.workspace.getActiveTextEditor()
+  selector.show(items, ({text, length}={}) =>{
+    const editor = atom.workspace.getActiveTextEditor()
     if (text == 'Automatic') {
       manual.delete(editor)
       run(editor)

--- a/lib/status.coffee
+++ b/lib/status.coffee
@@ -21,14 +21,21 @@ module.exports =
       atom.commands.dispatch atom.views.getView(atom.workspace.getActiveTextEditor()),
        'indent-detective:choose-indent'
 
-  updateText: ->
-    ed = atom.workspace.getActiveTextEditor()
-    if ed
-      if ed.getSoftTabs()
-        text = "Spaces (#{ed.getTabLength()})"
-      else
-        text = "Tabs"
-      @text?.innerText = text
+  update: ->
+    editor = atom.workspace.getActiveTextEditor()
+    if editor
+      @view.style.display = ""
+      @updateText editor
+    else
+      @view.style.display = "none"
+      @clearText()
 
-  clear: ->
+  updateText: (editor) ->
+    if editor.getSoftTabs()
+      text = "Spaces (#{editor.getTabLength()})"
+    else
+      text = "Tabs"
+    @text?.innerText = text
+
+  clearText: ->
     @text?.innerText = ""

--- a/lib/status.coffee
+++ b/lib/status.coffee
@@ -1,16 +1,15 @@
 module.exports =
   activate: ->
     @createView()
-    @subscription = atom.workspace.observeActivePaneItem =>
-      @update()
 
   deactivate: ->
     @tile?.destroy()
-    @subscription.dispose()
 
   consumeStatusBar: (bar) ->
     @bar = bar
-    @update()
+    @tile = @bar.addRightTile
+      item: @view
+      priority: 10.5
 
   createView: ->
     @view = document.createElement 'span'
@@ -22,15 +21,6 @@ module.exports =
       atom.commands.dispatch atom.views.getView(atom.workspace.getActiveTextEditor()),
        'indent-detective:choose-indent'
 
-  updateView: ->
-    return unless @bar?
-    if !atom.workspace.getActiveTextEditor()
-      @tile?.destroy()
-    else
-      @tile = @bar.addRightTile
-        item: @view
-        priority: 10.5
-
   updateText: ->
     ed = atom.workspace.getActiveTextEditor()
     if ed
@@ -40,6 +30,5 @@ module.exports =
         text = "Tabs"
       @text?.innerText = text
 
-  update: () ->
-    @updateView()
-    @updateText()
+  clear: ->
+    @text?.innerText = ""


### PR DESCRIPTION
## Purpose

I found this package keeps creating duplicated items on every editor observance, and this PR fixes this.

## Description

There are mainly two reasons for those duplicated creation:

1. This part keeps adding tiles to the status bar rather than updating it.
https://github.com/JunoLab/atom-indent-detective/blob/502180010b413565dd3fcef3dde062217e8bd605/lib/status.coffee#L27-L32

2. This subscription  keeps calling `@updateView`. (And actually it's even no longer needed since the same functionality is [implemented in `indent-detective.js` file](https://github.com/JunoLab/atom-indent-detective/blob/502180010b413565dd3fcef3dde062217e8bd605/lib/indent-detective.js#L17-L27) )
https://github.com/JunoLab/atom-indent-detective/blob/502180010b413565dd3fcef3dde062217e8bd605/lib/status.coffee#L4-L5

## Approach

This PR mainly includes these changes below:
- Delete the duplicated status-bar item creation
- When there is no active editor, don't destroy the status-bar item but rather just updating the element using `element.style.display` attribution
- Delete the duplicated subscription

## Results

Before:
![image](https://user-images.githubusercontent.com/40514306/60722251-4c2f5c00-9f6b-11e9-9083-e8a3fdfc7686.png)

After:
![image](https://user-images.githubusercontent.com/40514306/60722157-0a061a80-9f6b-11e9-8d67-22eed0f02fd3.png)


## Misc

I've also included the "`const` over `let` change" in the last commit
